### PR TITLE
Add service worker for offline caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'meterreader-v1';
+const URLS_TO_CACHE = [
+  './',
+  'index.html',
+  'styles.css',
+  'script.js',
+  'manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add a simple service worker to cache core assets for offline use

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885d68ac0e0832c844cb79b9154eaa2